### PR TITLE
Removed unused imports, added missing couchdbkit requirement

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,10 +1,9 @@
-from os import path
-
 import tornado.httpserver
 import tornado.ioloop
 import tornado.web
 
 import views
+
 
 def setup_app(settings):
     # intialize our tornado instance

--- a/app/views/viewlib.py
+++ b/app/views/viewlib.py
@@ -1,7 +1,6 @@
 
 import tornado.web
-from tornado.escape import json_encode, json_decode
-from tornroutes import route
+from tornado.escape import json_encode
 
 
 class BaseHandler(tornado.web.RequestHandler):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 tornado
 tornroutes
+couchdbkit

--- a/tests/torn_test_case.py
+++ b/tests/torn_test_case.py
@@ -1,22 +1,23 @@
 #!/usr/bin/env python
-import unittest, json, time
+import unittest
+import json
 from threading import Thread, Semaphore
-import sys, os
-import urllib, urllib2, cookielib, urlparse
+import urllib
+import urllib2
+import cookielib
+import urlparse
 
 from tornado.httpserver import HTTPServer
 from tornado.web import RequestHandler
 from tornado.ioloop import IOLoop
-
 from couchdbkit import Document
-
 
 __test__ = False
 
 
 class TornTestCase(unittest.TestCase):
 
-    def setUp(self,port):
+    def setUp(self, port):
         cj = cookielib.CookieJar()
         self.opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cj))
         self.baseurl = 'http://localhost:%d'%port

--- a/tests/view_tests.py
+++ b/tests/view_tests.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
-import unittest, json, time
-import sys, os
+import unittest
+import sys
+import os
 
 sys.path.insert(0,os.path.join(os.path.dirname(__file__), ".."))
 from test_settings import torn_settings


### PR DESCRIPTION
I tried running this app as a reintroduction to tornado and found some issues. I couldn't run without installing couchdbkit, hence I've added it to the requirements file. There were a number of unused imports which I got PyCharm to remove (in doing so it also fixed a PEP9 violation -- multiple imports on a single line).
